### PR TITLE
Add notifications history page with full test coverage

### DIFF
--- a/app/__test__/notification.test.tsx
+++ b/app/__test__/notification.test.tsx
@@ -1,0 +1,600 @@
+process.env.NEXT_PUBLIC_API_URL = "http://localhost:5000";
+
+import React from "react";
+import { render, screen, act, fireEvent } from "@testing-library/react";
+
+// Render portals inline so screen queries work without document.body traversal
+jest.mock("react-dom", () => ({
+  ...jest.requireActual("react-dom"),
+  createPortal: (node: React.ReactNode) => node,
+}));
+
+// jsdom does not implement requestAnimationFrame — stub it as a no-op so the
+// slide-in and progress-bar animations don't run during tests while the
+// underlying DOM nodes are still rendered and queryable.
+global.requestAnimationFrame = jest.fn(() => 0) as unknown as typeof requestAnimationFrame;
+global.cancelAnimationFrame = jest.fn();
+
+// ---------------------------------------------------------------------------
+// Socket mock — captures registered handlers so we can fire events manually
+// ---------------------------------------------------------------------------
+type Handler = (...args: unknown[]) => void;
+const capturedHandlers: Record<string, Handler[]> = {};
+
+const mockSocket = {
+  on: jest.fn((event: string, handler: Handler) => {
+    capturedHandlers[event] = capturedHandlers[event] ?? [];
+    capturedHandlers[event].push(handler);
+  }),
+  off: jest.fn((event: string, handler: Handler) => {
+    if (capturedHandlers[event]) {
+      capturedHandlers[event] = capturedHandlers[event].filter(
+        (h) => h !== handler,
+      );
+    }
+  }),
+  connected: true,
+};
+
+jest.mock("../contexts/SocketContext", () => ({
+  useSocket: () => ({ socket: mockSocket }),
+}));
+
+// Import after mocks are registered
+import {
+  NotificationProvider,
+  useNotifications,
+  OrderNotification,
+} from "../contexts/NotificationContext";
+import NotificationToast from "../presentation/components/NotificationToast";
+
+// ---------------------------------------------------------------------------
+// Test utilities
+// ---------------------------------------------------------------------------
+
+function emitSocketNotification(notification: OrderNotification) {
+  act(() => {
+    (capturedHandlers["order:notification"] ?? []).forEach((h) =>
+      h(notification),
+    );
+  });
+}
+
+function makeNotification(
+  overrides: Partial<OrderNotification> = {},
+): OrderNotification {
+  return {
+    id: "notif-1",
+    type: "order_created",
+    orderId: "order-abc",
+    tableNumber: 5,
+    customerName: "Alice",
+    itemCount: 3,
+    actor: { id: "user-1", name: "John Doe", role: "waiter" },
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+// Renders the context and exposes its state via data-testid attributes
+function NotificationSpy() {
+  const { notifications, history, dismiss, clearHistory } = useNotifications();
+  return (
+    <div>
+      <span data-testid="count">{notifications.length}</span>
+      <span data-testid="history-count">{history.length}</span>
+      <button data-testid="clear-history" onClick={clearHistory}>
+        Clear
+      </button>
+      {notifications.map((n) => (
+        <div key={n.id} data-testid={`notif-${n.id}`}>
+          <span data-testid={`type-${n.id}`}>{n.type}</span>
+          <span data-testid={`actor-${n.id}`}>{n.actor.name}</span>
+          <button
+            data-testid={`dismiss-${n.id}`}
+            onClick={() => dismiss(n.id)}
+          >
+            Dismiss
+          </button>
+        </div>
+      ))}
+      {history.map((n) => (
+        <div key={`h-${n.id}`} data-testid={`history-${n.id}`}>
+          <span data-testid={`history-type-${n.id}`}>{n.type}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// NotificationContext — unit tests for queue management
+// ---------------------------------------------------------------------------
+describe("NotificationContext", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.keys(capturedHandlers).forEach((k) => {
+      delete capturedHandlers[k];
+    });
+    // Fake timers for setTimeout (auto-dismiss), but keep RAF as our global stub
+    jest.useFakeTimers({
+      doNotFake: ["requestAnimationFrame", "cancelAnimationFrame"],
+    });
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  it("starts with an empty notification list", () => {
+    render(
+      <NotificationProvider>
+        <NotificationSpy />
+      </NotificationProvider>,
+    );
+    expect(screen.getByTestId("count")).toHaveTextContent("0");
+  });
+
+  it('registers a listener for "order:notification" on mount', () => {
+    render(
+      <NotificationProvider>
+        <NotificationSpy />
+      </NotificationProvider>,
+    );
+    expect(mockSocket.on).toHaveBeenCalledWith(
+      "order:notification",
+      expect.any(Function),
+    );
+  });
+
+  it('unregisters the listener for "order:notification" on unmount', () => {
+    const { unmount } = render(
+      <NotificationProvider>
+        <NotificationSpy />
+      </NotificationProvider>,
+    );
+    unmount();
+    expect(mockSocket.off).toHaveBeenCalledWith(
+      "order:notification",
+      expect.any(Function),
+    );
+  });
+
+  it("enqueues a notification when the socket event fires", () => {
+    render(
+      <NotificationProvider>
+        <NotificationSpy />
+      </NotificationProvider>,
+    );
+    emitSocketNotification(makeNotification());
+
+    expect(screen.getByTestId("count")).toHaveTextContent("1");
+    expect(screen.getByTestId("type-notif-1")).toHaveTextContent(
+      "order_created",
+    );
+    expect(screen.getByTestId("actor-notif-1")).toHaveTextContent("John Doe");
+  });
+
+  it("ignores a duplicate notification with the same id", () => {
+    render(
+      <NotificationProvider>
+        <NotificationSpy />
+      </NotificationProvider>,
+    );
+    const n = makeNotification({ id: "dup" });
+    emitSocketNotification(n);
+    emitSocketNotification(n);
+
+    expect(screen.getByTestId("count")).toHaveTextContent("1");
+  });
+
+  it("places the newest notification first", () => {
+    render(
+      <NotificationProvider>
+        <NotificationSpy />
+      </NotificationProvider>,
+    );
+    emitSocketNotification(makeNotification({ id: "old" }));
+    emitSocketNotification(makeNotification({ id: "new" }));
+
+    const cards = document.querySelectorAll("[data-testid^='notif-']");
+    expect(cards[0].getAttribute("data-testid")).toBe("notif-new");
+    expect(cards[1].getAttribute("data-testid")).toBe("notif-old");
+  });
+
+  it("caps the visible queue at 5 notifications", () => {
+    render(
+      <NotificationProvider>
+        <NotificationSpy />
+      </NotificationProvider>,
+    );
+    for (let i = 1; i <= 7; i++) {
+      emitSocketNotification(makeNotification({ id: `n${i}` }));
+    }
+    expect(screen.getByTestId("count")).toHaveTextContent("5");
+  });
+
+  it("auto-dismisses a notification after 6 seconds", () => {
+    render(
+      <NotificationProvider>
+        <NotificationSpy />
+      </NotificationProvider>,
+    );
+    emitSocketNotification(makeNotification({ id: "auto" }));
+    expect(screen.getByTestId("count")).toHaveTextContent("1");
+
+    act(() => {
+      jest.advanceTimersByTime(6_001);
+    });
+
+    expect(screen.getByTestId("count")).toHaveTextContent("0");
+  });
+
+  it("does not dismiss before 6 seconds have fully elapsed", () => {
+    render(
+      <NotificationProvider>
+        <NotificationSpy />
+      </NotificationProvider>,
+    );
+    emitSocketNotification(makeNotification({ id: "hold" }));
+
+    act(() => {
+      jest.advanceTimersByTime(5_000);
+    });
+
+    expect(screen.getByTestId("count")).toHaveTextContent("1");
+  });
+
+  it("dismiss() removes the specific notification immediately", () => {
+    render(
+      <NotificationProvider>
+        <NotificationSpy />
+      </NotificationProvider>,
+    );
+    emitSocketNotification(makeNotification({ id: "manual" }));
+    expect(screen.getByTestId("count")).toHaveTextContent("1");
+
+    fireEvent.click(screen.getByTestId("dismiss-manual"));
+
+    expect(screen.getByTestId("count")).toHaveTextContent("0");
+  });
+
+  it("dismiss() cancels the auto-dismiss timer so no double-update fires", () => {
+    render(
+      <NotificationProvider>
+        <NotificationSpy />
+      </NotificationProvider>,
+    );
+    emitSocketNotification(makeNotification({ id: "cancelled-timer" }));
+    fireEvent.click(screen.getByTestId("dismiss-cancelled-timer"));
+
+    // Advancing past the original timeout should not throw or change anything
+    act(() => {
+      jest.advanceTimersByTime(7_000);
+    });
+
+    expect(screen.getByTestId("count")).toHaveTextContent("0");
+  });
+
+  it("multiple different notification types are all enqueued", () => {
+    render(
+      <NotificationProvider>
+        <NotificationSpy />
+      </NotificationProvider>,
+    );
+    const types: OrderNotification["type"][] = [
+      "order_created",
+      "order_preparing",
+      "order_ready",
+      "order_served",
+    ];
+    types.forEach((type, i) =>
+      emitSocketNotification(makeNotification({ id: `t${i}`, type })),
+    );
+
+    expect(screen.getByTestId("count")).toHaveTextContent("4");
+    types.forEach((type, i) => {
+      expect(screen.getByTestId(`type-t${i}`)).toHaveTextContent(type);
+    });
+  });
+
+  // ---- History ------------------------------------------------------------ //
+
+  it("history starts empty", () => {
+    render(
+      <NotificationProvider>
+        <NotificationSpy />
+      </NotificationProvider>,
+    );
+    expect(screen.getByTestId("history-count")).toHaveTextContent("0");
+  });
+
+  it("history accumulates every received notification", () => {
+    render(
+      <NotificationProvider>
+        <NotificationSpy />
+      </NotificationProvider>,
+    );
+    emitSocketNotification(makeNotification({ id: "h1" }));
+    emitSocketNotification(makeNotification({ id: "h2" }));
+    emitSocketNotification(makeNotification({ id: "h3" }));
+
+    expect(screen.getByTestId("history-count")).toHaveTextContent("3");
+    expect(screen.getByTestId("history-h1")).toBeInTheDocument();
+    expect(screen.getByTestId("history-h2")).toBeInTheDocument();
+    expect(screen.getByTestId("history-h3")).toBeInTheDocument();
+  });
+
+  it("history is not cleared by auto-dismiss", () => {
+    render(
+      <NotificationProvider>
+        <NotificationSpy />
+      </NotificationProvider>,
+    );
+    emitSocketNotification(makeNotification({ id: "persist" }));
+
+    act(() => {
+      jest.advanceTimersByTime(6_001);
+    });
+
+    // Active toast gone, history entry still present
+    expect(screen.getByTestId("count")).toHaveTextContent("0");
+    expect(screen.getByTestId("history-count")).toHaveTextContent("1");
+  });
+
+  it("history is not cleared by manual dismiss()", () => {
+    render(
+      <NotificationProvider>
+        <NotificationSpy />
+      </NotificationProvider>,
+    );
+    emitSocketNotification(makeNotification({ id: "keep-hist" }));
+    fireEvent.click(screen.getByTestId("dismiss-keep-hist"));
+
+    expect(screen.getByTestId("count")).toHaveTextContent("0");
+    expect(screen.getByTestId("history-count")).toHaveTextContent("1");
+  });
+
+  it("history deduplicates by id", () => {
+    render(
+      <NotificationProvider>
+        <NotificationSpy />
+      </NotificationProvider>,
+    );
+    const n = makeNotification({ id: "dup-h" });
+    emitSocketNotification(n);
+    emitSocketNotification(n);
+
+    expect(screen.getByTestId("history-count")).toHaveTextContent("1");
+  });
+
+  it("clearHistory empties the history list", () => {
+    render(
+      <NotificationProvider>
+        <NotificationSpy />
+      </NotificationProvider>,
+    );
+    emitSocketNotification(makeNotification({ id: "clr1" }));
+    emitSocketNotification(makeNotification({ id: "clr2" }));
+    expect(screen.getByTestId("history-count")).toHaveTextContent("2");
+
+    fireEvent.click(screen.getByTestId("clear-history"));
+
+    expect(screen.getByTestId("history-count")).toHaveTextContent("0");
+  });
+
+  it("new notifications are still enqueued after clearHistory", () => {
+    render(
+      <NotificationProvider>
+        <NotificationSpy />
+      </NotificationProvider>,
+    );
+    emitSocketNotification(makeNotification({ id: "before" }));
+    fireEvent.click(screen.getByTestId("clear-history"));
+    emitSocketNotification(makeNotification({ id: "after" }));
+
+    expect(screen.getByTestId("history-count")).toHaveTextContent("1");
+    expect(screen.getByTestId("history-after")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NotificationToast — component rendering tests
+// ---------------------------------------------------------------------------
+describe("NotificationToast", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.keys(capturedHandlers).forEach((k) => {
+      delete capturedHandlers[k];
+    });
+    jest.useFakeTimers({
+      doNotFake: ["requestAnimationFrame", "cancelAnimationFrame"],
+    });
+  });
+
+  afterEach(() => {
+    // Flush pending timers inside act so state updates (auto-dismiss) don't
+    // trigger "not wrapped in act" warnings between tests.
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  function renderToast() {
+    return render(
+      <NotificationProvider>
+        <NotificationToast />
+      </NotificationProvider>,
+    );
+  }
+
+  // ---- Empty state ------------------------------------------------------- //
+
+  it("renders nothing when there are no notifications", () => {
+    renderToast();
+    expect(screen.queryByText("New Order")).not.toBeInTheDocument();
+    expect(screen.queryByText("Now Preparing")).not.toBeInTheDocument();
+    expect(screen.queryByText("Ready to Serve")).not.toBeInTheDocument();
+    expect(screen.queryByText("Order Served")).not.toBeInTheDocument();
+  });
+
+  // ---- Type labels ------------------------------------------------------- //
+
+  it.each([
+    ["order_created" as const, "New Order"],
+    ["order_preparing" as const, "Now Preparing"],
+    ["order_ready" as const, "Ready to Serve"],
+    ["order_served" as const, "Order Served"],
+  ])('shows "%s" label for %s notification', (type, expectedLabel) => {
+    renderToast();
+    emitSocketNotification(makeNotification({ id: type, type }));
+    expect(screen.getByText(expectedLabel)).toBeInTheDocument();
+  });
+
+  // ---- Location display -------------------------------------------------- //
+
+  it("shows the table number when present", () => {
+    renderToast();
+    emitSocketNotification(makeNotification({ tableNumber: 12 }));
+    expect(screen.getByText(/Table 12/)).toBeInTheDocument();
+  });
+
+  it("shows the customer name when there is no table number", () => {
+    renderToast();
+    emitSocketNotification(
+      makeNotification({ tableNumber: undefined, customerName: "Charlie" }),
+    );
+    expect(screen.getByText(/Charlie/)).toBeInTheDocument();
+  });
+
+  it('falls back to "Takeaway / Delivery" when neither table nor customer name', () => {
+    renderToast();
+    emitSocketNotification(
+      makeNotification({ tableNumber: undefined, customerName: undefined }),
+    );
+    expect(screen.getByText(/Takeaway \/ Delivery/)).toBeInTheDocument();
+  });
+
+  // ---- Item count -------------------------------------------------------- //
+
+  it('shows item count with plural "items"', () => {
+    renderToast();
+    emitSocketNotification(makeNotification({ itemCount: 4 }));
+    expect(screen.getByText(/4 items/)).toBeInTheDocument();
+  });
+
+  it('uses singular "item" when itemCount is 1', () => {
+    renderToast();
+    emitSocketNotification(makeNotification({ itemCount: 1 }));
+    expect(screen.getByText(/· 1 item$/)).toBeInTheDocument();
+    expect(screen.queryByText(/1 items/)).not.toBeInTheDocument();
+  });
+
+  // ---- Actor info -------------------------------------------------------- //
+
+  it("displays the actor name", () => {
+    renderToast();
+    emitSocketNotification(
+      makeNotification({
+        actor: { id: "u1", name: "Chef Marco", role: "chef" },
+      }),
+    );
+    expect(screen.getByText("Chef Marco")).toBeInTheDocument();
+  });
+
+  it.each([
+    ["admin", "Admin"],
+    ["manager", "Manager"],
+    ["chef", "Chef"],
+    ["waiter", "Waiter"],
+    ["cashier", "Cashier"],
+    ["customer", "Customer"],
+  ])('shows "%s" role badge for role "%s"', (role, expectedLabel) => {
+    renderToast();
+    emitSocketNotification(
+      makeNotification({
+        id: `role-${role}`,
+        actor: { id: "u", name: "Test User", role },
+      }),
+    );
+    expect(screen.getByText(expectedLabel)).toBeInTheDocument();
+  });
+
+  // ---- Timestamp --------------------------------------------------------- //
+
+  it('shows "Just now" for a freshly created notification', () => {
+    renderToast();
+    emitSocketNotification(
+      makeNotification({ timestamp: new Date().toISOString() }),
+    );
+    expect(screen.getByText("Just now")).toBeInTheDocument();
+  });
+
+  // ---- Multi-toast ------------------------------------------------------- //
+
+  it("renders a card for each notification in the queue", () => {
+    renderToast();
+    emitSocketNotification(makeNotification({ id: "a", type: "order_created" }));
+    emitSocketNotification(makeNotification({ id: "b", type: "order_ready" }));
+
+    expect(screen.getByText("New Order")).toBeInTheDocument();
+    expect(screen.getByText("Ready to Serve")).toBeInTheDocument();
+  });
+
+  // ---- Dismiss ----------------------------------------------------------- //
+
+  it("clicking the dismiss button removes that toast", () => {
+    renderToast();
+    emitSocketNotification(makeNotification({ id: "dismiss-me" }));
+    expect(screen.getByText("New Order")).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /dismiss notification/i }),
+    );
+
+    expect(screen.queryByText("New Order")).not.toBeInTheDocument();
+  });
+
+  it("only removes the dismissed toast, leaving others intact", () => {
+    renderToast();
+    emitSocketNotification(makeNotification({ id: "keep", type: "order_ready" }));
+    emitSocketNotification(makeNotification({ id: "remove", type: "order_created" }));
+
+    // Two toasts are rendered — one dismiss button each; click the first
+    // (newest-first order means "New Order" button is first in the DOM)
+    const buttons = screen.getAllByRole("button", { name: /dismiss notification/i });
+    fireEvent.click(buttons[0]);
+
+    expect(screen.queryByText("New Order")).not.toBeInTheDocument();
+    expect(screen.getByText("Ready to Serve")).toBeInTheDocument();
+  });
+
+  // ---- Auto-dismiss ------------------------------------------------------ //
+
+  it("toasts disappear after the 6-second auto-dismiss window", () => {
+    renderToast();
+    emitSocketNotification(makeNotification({ id: "fade" }));
+    expect(screen.getByText("New Order")).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(6_001);
+    });
+
+    expect(screen.queryByText("New Order")).not.toBeInTheDocument();
+  });
+
+  it("does not hide the toast before 6 seconds have elapsed", () => {
+    renderToast();
+    emitSocketNotification(makeNotification({ id: "stay" }));
+
+    act(() => {
+      jest.advanceTimersByTime(5_000);
+    });
+
+    expect(screen.getByText("New Order")).toBeInTheDocument();
+  });
+});

--- a/app/__test__/notificationsPage.test.tsx
+++ b/app/__test__/notificationsPage.test.tsx
@@ -1,0 +1,246 @@
+process.env.NEXT_PUBLIC_API_URL = "http://localhost:5000";
+
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { OrderNotification } from "../contexts/NotificationContext";
+
+// ---------------------------------------------------------------------------
+// Mock useNotifications — the page is a pure consumer, no socket needed
+// ---------------------------------------------------------------------------
+
+const mockClearHistory = jest.fn();
+let mockHistory: OrderNotification[] = [];
+
+jest.mock("../contexts/NotificationContext", () => ({
+  useNotifications: () => ({
+    history: mockHistory,
+    clearHistory: mockClearHistory,
+  }),
+  // Re-export the type constant so the page import doesn't break
+  NotificationType: {},
+}));
+
+// Import after mocks
+import NotificationsPage from "../notifications/page";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeNotification(
+  overrides: Partial<OrderNotification> = {},
+): OrderNotification {
+  return {
+    id: "n1",
+    type: "order_created",
+    orderId: "order-abc",
+    tableNumber: 5,
+    customerName: "Alice",
+    itemCount: 3,
+    actor: { id: "u1", name: "John Doe", role: "waiter" },
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  return render(<NotificationsPage />);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("NotificationsPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHistory = [];
+  });
+
+  // ---- Empty state -------------------------------------------------------- //
+
+  it("shows the empty state when there are no notifications", () => {
+    renderPage();
+    expect(screen.getByText("No notifications yet")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Order events will appear here in real time/),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render a 'Clear all' button when history is empty", () => {
+    renderPage();
+    expect(
+      screen.queryByRole("button", { name: /clear all/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the total count in the header subtitle", () => {
+    mockHistory = [makeNotification({ id: "a" }), makeNotification({ id: "b" })];
+    renderPage();
+    expect(screen.getByText("2 total received this session")).toBeInTheDocument();
+  });
+
+  // ---- Notification cards ------------------------------------------------- //
+
+  it("renders a card for each history entry", () => {
+    mockHistory = [
+      makeNotification({ id: "c1", type: "order_created" }),
+      makeNotification({ id: "c2", type: "order_ready" }),
+    ];
+    renderPage();
+    expect(screen.getByText("New Order")).toBeInTheDocument();
+    expect(screen.getByText("Ready to Serve")).toBeInTheDocument();
+  });
+
+  it("shows table number on the card", () => {
+    mockHistory = [makeNotification({ tableNumber: 7 })];
+    renderPage();
+    expect(screen.getByText(/Table 7/)).toBeInTheDocument();
+  });
+
+  it("shows customer name when there is no table number", () => {
+    mockHistory = [
+      makeNotification({ tableNumber: undefined, customerName: "Maria" }),
+    ];
+    renderPage();
+    expect(screen.getByText(/Maria/)).toBeInTheDocument();
+  });
+
+  it('falls back to "Takeaway / Delivery" when no table or customer', () => {
+    mockHistory = [
+      makeNotification({ tableNumber: undefined, customerName: undefined }),
+    ];
+    renderPage();
+    expect(screen.getByText(/Takeaway \/ Delivery/)).toBeInTheDocument();
+  });
+
+  it("shows item count with plural label", () => {
+    mockHistory = [makeNotification({ itemCount: 4 })];
+    renderPage();
+    expect(screen.getByText(/4 items/)).toBeInTheDocument();
+  });
+
+  it('uses singular "item" when itemCount is 1', () => {
+    mockHistory = [makeNotification({ itemCount: 1 })];
+    renderPage();
+    expect(screen.getByText(/· 1 item/)).toBeInTheDocument();
+    expect(screen.queryByText(/1 items/)).not.toBeInTheDocument();
+  });
+
+  it("shows the actor name and role badge on the card", () => {
+    mockHistory = [
+      makeNotification({
+        actor: { id: "u2", name: "Chef Marco", role: "chef" },
+      }),
+    ];
+    renderPage();
+    expect(screen.getByText("Chef Marco")).toBeInTheDocument();
+    expect(screen.getByText("Chef")).toBeInTheDocument();
+  });
+
+  // ---- Type labels on cards ---------------------------------------------- //
+
+  it.each([
+    ["order_created" as const, "New Order"],
+    ["order_preparing" as const, "Now Preparing"],
+    ["order_ready" as const, "Ready to Serve"],
+    ["order_served" as const, "Order Served"],
+  ])('card label is "%s" for type %s', (type, label) => {
+    mockHistory = [makeNotification({ id: type, type })];
+    renderPage();
+    expect(screen.getByText(label)).toBeInTheDocument();
+  });
+
+  // ---- Clear all ---------------------------------------------------------- //
+
+  it("shows 'Clear all' button when history has entries", () => {
+    mockHistory = [makeNotification()];
+    renderPage();
+    expect(
+      screen.getByRole("button", { name: /clear all/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("calls clearHistory when 'Clear all' is clicked", () => {
+    mockHistory = [makeNotification()];
+    renderPage();
+    fireEvent.click(screen.getByRole("button", { name: /clear all/i }));
+    expect(mockClearHistory).toHaveBeenCalledTimes(1);
+  });
+
+  // ---- Filter tabs -------------------------------------------------------- //
+
+  it("renders all five filter tabs", () => {
+    renderPage();
+    expect(screen.getByRole("button", { name: /^All/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /New Orders/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Preparing/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Ready/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Served/i })).toBeInTheDocument();
+  });
+
+  it("filters to only order_created when 'New Orders' tab is active", () => {
+    mockHistory = [
+      makeNotification({ id: "x1", type: "order_created" }),
+      makeNotification({ id: "x2", type: "order_ready" }),
+    ];
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: /New Orders/i }));
+
+    expect(screen.getByText("New Order")).toBeInTheDocument();
+    expect(screen.queryByText("Ready to Serve")).not.toBeInTheDocument();
+  });
+
+  it("filters to only order_ready when 'Ready' tab is active", () => {
+    mockHistory = [
+      makeNotification({ id: "y1", type: "order_created" }),
+      makeNotification({ id: "y2", type: "order_ready" }),
+    ];
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: /^Ready/i }));
+
+    expect(screen.getByText("Ready to Serve")).toBeInTheDocument();
+    expect(screen.queryByText("New Order")).not.toBeInTheDocument();
+  });
+
+  it("shows all entries when 'All' tab is selected after a filter", () => {
+    mockHistory = [
+      makeNotification({ id: "z1", type: "order_created" }),
+      makeNotification({ id: "z2", type: "order_served" }),
+    ];
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: /Served/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^All/i }));
+
+    expect(screen.getByText("New Order")).toBeInTheDocument();
+    expect(screen.getByText("Order Served")).toBeInTheDocument();
+  });
+
+  it("shows the empty state when the active filter has no matches", () => {
+    mockHistory = [makeNotification({ type: "order_created" })];
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: /Served/i }));
+
+    expect(screen.getByText("No notifications yet")).toBeInTheDocument();
+  });
+
+  it("tab count badges reflect the number of notifications for that type", () => {
+    mockHistory = [
+      makeNotification({ id: "b1", type: "order_created" }),
+      makeNotification({ id: "b2", type: "order_created" }),
+      makeNotification({ id: "b3", type: "order_ready" }),
+    ];
+    renderPage();
+
+    // The "All" tab badge should show 3; "New Orders" should show 2
+    const allBtn = screen.getByRole("button", { name: /^All/i });
+    const newOrdersBtn = screen.getByRole("button", { name: /New Orders/i });
+
+    expect(allBtn).toHaveTextContent("3");
+    expect(newOrdersBtn).toHaveTextContent("2");
+  });
+});

--- a/app/contexts/NotificationContext.tsx
+++ b/app/contexts/NotificationContext.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useEffect,
+  useRef,
+} from "react";
+import { useSocket } from "./SocketContext";
+
+// ---------------------------------------------------------------------------
+// Shared type — re-export so the toast component imports from one place
+// ---------------------------------------------------------------------------
+
+export type NotificationType =
+  | "order_created"
+  | "order_preparing"
+  | "order_ready"
+  | "order_served";
+
+export interface OrderNotification {
+  /** Unique id — used as React key and for dismissal */
+  id: string;
+  type: NotificationType;
+  orderId: string;
+  tableNumber?: number;
+  customerName?: string;
+  itemCount: number;
+  actor: { id: string; name: string; role: string };
+  /** ISO timestamp from the server */
+  timestamp: string;
+}
+
+// ---------------------------------------------------------------------------
+// Context shape
+// ---------------------------------------------------------------------------
+
+interface NotificationContextType {
+  notifications: OrderNotification[];
+  history: OrderNotification[];
+  dismiss: (id: string) => void;
+  clearHistory: () => void;
+}
+
+const MAX_HISTORY = 100;
+
+const NotificationContext = createContext<NotificationContextType>({
+  notifications: [],
+  history: [],
+  dismiss: () => {},
+  clearHistory: () => {},
+});
+
+export const useNotifications = () => useContext(NotificationContext);
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MAX_VISIBLE = 5;
+const AUTO_DISMISS_MS = 6_000;
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+export const NotificationProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [notifications, setNotifications] = useState<OrderNotification[]>([]);
+  const [history, setHistory] = useState<OrderNotification[]>([]);
+  const { socket } = useSocket();
+
+  // Keep a ref to timers so we can cancel on unmount
+  const timers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  const dismiss = useCallback((id: string) => {
+    setNotifications((prev) => prev.filter((n) => n.id !== id));
+    const timer = timers.current.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      timers.current.delete(id);
+    }
+  }, []);
+
+  const clearHistory = useCallback(() => {
+    setHistory([]);
+  }, []);
+
+  const enqueue = useCallback(
+    (notification: OrderNotification) => {
+      setNotifications((prev) => {
+        if (prev.some((n) => n.id === notification.id)) return prev;
+        return [notification, ...prev].slice(0, MAX_VISIBLE);
+      });
+
+      setHistory((prev) => {
+        if (prev.some((n) => n.id === notification.id)) return prev;
+        return [notification, ...prev].slice(0, MAX_HISTORY);
+      });
+
+      const timer = setTimeout(() => dismiss(notification.id), AUTO_DISMISS_MS);
+      timers.current.set(notification.id, timer);
+    },
+    [dismiss],
+  );
+
+  useEffect(() => {
+    if (!socket) return;
+
+    socket.on("order:notification", enqueue);
+
+    return () => {
+      socket.off("order:notification", enqueue);
+    };
+  }, [socket, enqueue]);
+
+  // Clean up all timers on unmount
+  useEffect(() => {
+    const t = timers.current;
+    return () => {
+      t.forEach((timer) => clearTimeout(timer));
+      t.clear();
+    };
+  }, []);
+
+  return (
+    <NotificationContext.Provider value={{ notifications, history, dismiss, clearHistory }}>
+      {children}
+    </NotificationContext.Provider>
+  );
+};

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,6 +8,8 @@ import { AuthProvider } from "./contexts/AuthContext";
 import { SearchProvider } from "./contexts/SearchContext";
 import { SocketProvider } from "./contexts/SocketContext";
 import { WebSocketProvider } from "./contexts/WebSocketContext";
+import { NotificationProvider } from "./contexts/NotificationContext";
+import NotificationToast from "./presentation/components/NotificationToast";
 import Layout from "./presentation/components/layout";
 
 const ibmPlexSans = localFont({
@@ -42,12 +44,16 @@ const RootLayout = async ({ children }: { children: ReactNode }) => {
         <AuthProvider>
           <SocketProvider>
             <WebSocketProvider>
-              <SearchProvider>
-                <div className="flex flex-col min-h-screen mx-auto">
-                  <Layout />
-                  <main className="flex-1 ml-[83.40px]">{children}</main>
-                </div>
-              </SearchProvider>
+              <NotificationProvider>
+                <SearchProvider>
+                  <div className="flex flex-col min-h-screen mx-auto">
+                    <Layout />
+                    <main className="flex-1 ml-[83.40px]">{children}</main>
+                  </div>
+                </SearchProvider>
+                {/* Global notification toasts — portal to document.body */}
+                <NotificationToast />
+              </NotificationProvider>
             </WebSocketProvider>
           </SocketProvider>
         </AuthProvider>

--- a/app/notifications/page.tsx
+++ b/app/notifications/page.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useState } from "react";
+import { Bell, Trash2 } from "lucide-react";
+import {
+  useNotifications,
+  OrderNotification,
+  NotificationType,
+} from "../contexts/NotificationContext";
+
+const TYPE_CONFIG: Record<
+  NotificationType,
+  { icon: string; label: string; borderColor: string; iconBg: string; labelColor: string; badgeBg: string }
+> = {
+  order_created: {
+    icon: "🆕",
+    label: "New Order",
+    borderColor: "border-blue-400",
+    iconBg: "bg-blue-100",
+    labelColor: "text-blue-700",
+    badgeBg: "bg-blue-100 text-blue-700",
+  },
+  order_preparing: {
+    icon: "👨‍🍳",
+    label: "Now Preparing",
+    borderColor: "border-amber-400",
+    iconBg: "bg-amber-100",
+    labelColor: "text-amber-700",
+    badgeBg: "bg-amber-100 text-amber-700",
+  },
+  order_ready: {
+    icon: "✅",
+    label: "Ready to Serve",
+    borderColor: "border-green-400",
+    iconBg: "bg-green-100",
+    labelColor: "text-green-700",
+    badgeBg: "bg-green-100 text-green-700",
+  },
+  order_served: {
+    icon: "🍽️",
+    label: "Order Served",
+    borderColor: "border-gray-400",
+    iconBg: "bg-gray-100",
+    labelColor: "text-gray-600",
+    badgeBg: "bg-gray-100 text-gray-600",
+  },
+};
+
+const ROLE_LABELS: Record<string, string> = {
+  admin: "Admin",
+  manager: "Manager",
+  chef: "Chef",
+  waiter: "Waiter",
+  cashier: "Cashier",
+  customer: "Customer",
+};
+
+const FILTER_TABS: { value: NotificationType | "all"; label: string }[] = [
+  { value: "all", label: "All" },
+  { value: "order_created", label: "New Orders" },
+  { value: "order_preparing", label: "Preparing" },
+  { value: "order_ready", label: "Ready" },
+  { value: "order_served", label: "Served" },
+];
+
+function formatTime(iso: string): string {
+  const date = new Date(iso);
+  const diff = Date.now() - date.getTime();
+  if (diff < 60_000) return "Just now";
+  if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+  if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+}
+
+function NotificationCard({ notification }: { notification: OrderNotification }) {
+  const config = TYPE_CONFIG[notification.type];
+  const roleLabel = ROLE_LABELS[notification.actor.role] ?? notification.actor.role;
+
+  return (
+    <div className={`flex items-start gap-4 p-4 bg-white rounded-xl border border-gray-100 border-l-4 ${config.borderColor} shadow-sm`}>
+      <div className={`flex-shrink-0 w-10 h-10 rounded-full flex items-center justify-center text-lg ${config.iconBg}`}>
+        {config.icon}
+      </div>
+
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className={`text-xs font-semibold px-2 py-0.5 rounded-full ${config.badgeBg}`}>
+            {config.label}
+          </span>
+          <span className="text-xs text-gray-400">{formatTime(notification.timestamp)}</span>
+        </div>
+
+        <p className="text-sm font-medium text-gray-800 mt-1">
+          {notification.tableNumber
+            ? `Table ${notification.tableNumber}`
+            : notification.customerName ?? "Takeaway / Delivery"}
+          {notification.itemCount > 0 && (
+            <span className="text-gray-500 font-normal">
+              {" · "}{notification.itemCount} {notification.itemCount === 1 ? "item" : "items"}
+            </span>
+          )}
+        </p>
+
+        <p className="text-xs text-gray-500 mt-0.5">
+          By <span className="font-medium text-gray-700">{notification.actor.name}</span>
+          <span className="ml-1 inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium bg-gray-100 text-gray-600">
+            {roleLabel}
+          </span>
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default function NotificationsPage() {
+  const { history, clearHistory } = useNotifications();
+  const [activeFilter, setActiveFilter] = useState<NotificationType | "all">("all");
+
+  const filtered = activeFilter === "all"
+    ? history
+    : history.filter((n) => n.type === activeFilter);
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-6 mt-18">
+      <div className="max-w-3xl mx-auto">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-6">
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 bg-blue-100 rounded-xl flex items-center justify-center">
+              <Bell className="w-5 h-5 text-blue-600" />
+            </div>
+            <div>
+              <h1 className="text-2xl font-bold text-gray-900">Notifications</h1>
+              <p className="text-sm text-gray-500">{history.length} total received this session</p>
+            </div>
+          </div>
+
+          {history.length > 0 && (
+            <button
+              onClick={clearHistory}
+              className="flex items-center gap-2 px-3 py-2 text-sm text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+            >
+              <Trash2 className="w-4 h-4" />
+              Clear all
+            </button>
+          )}
+        </div>
+
+        {/* Filter tabs */}
+        <div className="flex gap-2 flex-wrap mb-6">
+          {FILTER_TABS.map((tab) => {
+            const count = tab.value === "all"
+              ? history.length
+              : history.filter((n) => n.type === tab.value).length;
+            return (
+              <button
+                key={tab.value}
+                onClick={() => setActiveFilter(tab.value)}
+                className={`px-3 py-1.5 text-sm rounded-lg font-medium transition-colors ${
+                  activeFilter === tab.value
+                    ? "bg-blue-600 text-white"
+                    : "bg-white text-gray-600 hover:bg-gray-100 border border-gray-200"
+                }`}
+              >
+                {tab.label}
+                {count > 0 && (
+                  <span className={`ml-1.5 text-xs px-1.5 py-0.5 rounded-full ${
+                    activeFilter === tab.value ? "bg-blue-500 text-white" : "bg-gray-100 text-gray-500"
+                  }`}>
+                    {count}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* List */}
+        {filtered.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-24 text-center">
+            <div className="w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center mb-4">
+              <Bell className="w-8 h-8 text-gray-400" />
+            </div>
+            <h3 className="text-lg font-semibold text-gray-700">No notifications yet</h3>
+            <p className="text-sm text-gray-400 mt-1">
+              Order events will appear here in real time.
+            </p>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {filtered.map((n) => (
+              <NotificationCard key={n.id} notification={n} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/presentation/components/NotificationToast.tsx
+++ b/app/presentation/components/NotificationToast.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import {
+  useNotifications,
+  OrderNotification,
+  NotificationType,
+} from "../../contexts/NotificationContext";
+
+// ---------------------------------------------------------------------------
+// Per-type visual config
+// ---------------------------------------------------------------------------
+
+const TYPE_CONFIG: Record<
+  NotificationType,
+  {
+    icon: string;
+    label: string;
+    borderColor: string;
+    iconBg: string;
+    labelColor: string;
+    progressColor: string;
+  }
+> = {
+  order_created: {
+    icon: "🆕",
+    label: "New Order",
+    borderColor: "border-blue-400",
+    iconBg: "bg-blue-100",
+    labelColor: "text-blue-700",
+    progressColor: "bg-blue-400",
+  },
+  order_preparing: {
+    icon: "👨‍🍳",
+    label: "Now Preparing",
+    borderColor: "border-amber-400",
+    iconBg: "bg-amber-100",
+    labelColor: "text-amber-700",
+    progressColor: "bg-amber-400",
+  },
+  order_ready: {
+    icon: "✅",
+    label: "Ready to Serve",
+    borderColor: "border-green-400",
+    iconBg: "bg-green-100",
+    labelColor: "text-green-700",
+    progressColor: "bg-green-400",
+  },
+  order_served: {
+    icon: "🍽️",
+    label: "Order Served",
+    borderColor: "border-gray-400",
+    iconBg: "bg-gray-100",
+    labelColor: "text-gray-700",
+    progressColor: "bg-gray-400",
+  },
+};
+
+const ROLE_LABELS: Record<string, string> = {
+  admin: "Admin",
+  manager: "Manager",
+  chef: "Chef",
+  waiter: "Waiter",
+  cashier: "Cashier",
+  customer: "Customer",
+};
+
+const AUTO_DISMISS_MS = 6_000;
+
+// ---------------------------------------------------------------------------
+// Single toast card
+// ---------------------------------------------------------------------------
+
+function ToastCard({
+  notification,
+  onDismiss,
+}: {
+  notification: OrderNotification;
+  onDismiss: (id: string) => void;
+}) {
+  const config = TYPE_CONFIG[notification.type];
+  const [visible, setVisible] = useState(false);
+  // progress bar width 100 → 0 over AUTO_DISMISS_MS
+  const [progress, setProgress] = useState(100);
+  const rafRef = useRef<number | null>(null);
+  const startRef = useRef<number | null>(null);
+
+  // Slide-in on mount
+  useEffect(() => {
+    const id = requestAnimationFrame(() => setVisible(true));
+    return () => cancelAnimationFrame(id);
+  }, []);
+
+  // Animate progress bar with rAF for perfect smoothness
+  useEffect(() => {
+    const tick = (now: number) => {
+      if (!startRef.current) startRef.current = now;
+      const elapsed = now - startRef.current;
+      const remaining = Math.max(0, 100 - (elapsed / AUTO_DISMISS_MS) * 100);
+      setProgress(remaining);
+      if (remaining > 0) {
+        rafRef.current = requestAnimationFrame(tick);
+      }
+    };
+    rafRef.current = requestAnimationFrame(tick);
+    return () => {
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
+    };
+  }, []);
+
+  const timeAgo = (() => {
+    const diff = Date.now() - new Date(notification.timestamp).getTime();
+    if (diff < 5_000) return "Just now";
+    if (diff < 60_000) return `${Math.floor(diff / 1_000)}s ago`;
+    return `${Math.floor(diff / 60_000)}m ago`;
+  })();
+
+  const roleLabel =
+    ROLE_LABELS[notification.actor.role] ?? notification.actor.role;
+
+  return (
+    <div
+      className={`
+        relative flex flex-col w-80 bg-white rounded-xl shadow-lg border-l-4
+        overflow-hidden transition-all duration-300 ease-out
+        ${config.borderColor}
+        ${visible ? "translate-x-0 opacity-100" : "translate-x-full opacity-0"}
+      `}
+    >
+      {/* Main content row */}
+      <div className="flex items-start gap-3 p-4 pr-10">
+        {/* Icon */}
+        <div
+          className={`flex-shrink-0 w-10 h-10 rounded-full flex items-center justify-center text-lg ${config.iconBg}`}
+        >
+          {config.icon}
+        </div>
+
+        {/* Text */}
+        <div className="flex-1 min-w-0">
+          <p className={`text-sm font-semibold ${config.labelColor}`}>
+            {config.label}
+          </p>
+
+          {/* Table + item count */}
+          <p className="text-sm text-gray-800 font-medium mt-0.5">
+            {notification.tableNumber
+              ? `Table ${notification.tableNumber}`
+              : notification.customerName ?? "Takeaway / Delivery"}
+            {notification.itemCount > 0 && (
+              <span className="text-gray-500 font-normal">
+                {" · "}
+                {notification.itemCount}{" "}
+                {notification.itemCount === 1 ? "item" : "items"}
+              </span>
+            )}
+          </p>
+
+          {/* Actor */}
+          <p className="text-xs text-gray-500 mt-1 truncate">
+            By{" "}
+            <span className="font-medium text-gray-700">
+              {notification.actor.name}
+            </span>
+            <span className="ml-1 inline-flex items-center px-1.5 py-0.5 rounded-full text-[10px] font-medium bg-gray-100 text-gray-600">
+              {roleLabel}
+            </span>
+          </p>
+
+          {/* Timestamp */}
+          <p className="text-[10px] text-gray-400 mt-0.5">{timeAgo}</p>
+        </div>
+      </div>
+
+      {/* Dismiss button */}
+      <button
+        onClick={() => onDismiss(notification.id)}
+        className="absolute top-3 right-3 text-gray-400 hover:text-gray-600 transition-colors p-0.5 rounded"
+        aria-label="Dismiss notification"
+      >
+        <svg
+          className="w-4 h-4"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M6 18L18 6M6 6l12 12"
+          />
+        </svg>
+      </button>
+
+      {/* Auto-dismiss progress bar */}
+      <div className="h-1 bg-gray-100">
+        <div
+          className={`h-full transition-none ${config.progressColor}`}
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Container — portal into document.body
+// ---------------------------------------------------------------------------
+
+export default function NotificationToast() {
+  const { notifications, dismiss } = useNotifications();
+  const [mounted, setMounted] = useState(false);
+
+  // Avoid SSR mismatch — portals need the DOM
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted || notifications.length === 0) return null;
+
+  return createPortal(
+    <div
+      className="fixed bottom-6 right-6 z-[9999] flex flex-col-reverse gap-3 pointer-events-none"
+      aria-live="polite"
+      aria-label="Order notifications"
+    >
+      {notifications.map((n) => (
+        <div key={n.id} className="pointer-events-auto">
+          <ToastCard notification={n} onDismiss={dismiss} />
+        </div>
+      ))}
+    </div>,
+    document.body,
+  );
+}


### PR DESCRIPTION
- NotificationContext: add persistent `history` array (max 100, newest-first) and `clearHistory()` alongside the existing auto-dismissing toast queue
- app/notifications/page.tsx: new route at /notifications displaying all received notifications with type filter tabs, per-type count badges, and a clear-all button
- NotificationToast.tsx: no behaviour changes, carried over as new file on this branch
- notification.test.tsx: extend spy component to expose history; add 8 new cases covering history accumulation, auto-dismiss isolation, manual-dismiss isolation, deduplication, clearHistory, and post-clear enqueue
- notificationsPage.test.tsx: 24 new cases covering empty state, card rendering, all four type labels, table/customer/fallback display, item count singular/plural, actor name and role badge, clear-all button visibility and callback, all five filter tabs, filter isolation, reset to All, empty filtered state, and tab count badges