### PR TITLE
Fix CI deploy step: replace unmaintained vercel-action with direct CLI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,9 +37,14 @@ jobs:
         run: npm run build
 
       - name: Deploy to Vercel
-        uses: amondnet/vercel-action@v25
-        with:
-          vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          vercel-org-id: ${{ secrets.ORG_ID }}
-          vercel-project-id: ${{ secrets.PROJECT_ID }}
-          vercel-args: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && '--prod' || '' }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.PROJECT_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          npm install --global vercel@latest
+          if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            vercel --token "$VERCEL_TOKEN" --prod --yes
+          else
+            vercel --token "$VERCEL_TOKEN" --yes
+          fi


### PR DESCRIPTION
amondnet/vercel-action@v25 pins Vercel CLI 25.1.0, which is rejected by Vercel's API (requires >=47.2.2). Replace with a plain run step that installs vercel@latest at job time, so the version always satisfies the API. Production deployments (--prod) are preserved for direct pushes to main; preview deployments fire for every other trigger.