### PR TITLE
fix: eliminate full re-render on kitchen status update via optimistic…

### DIFF
--- a/app/(waiter_order)/KitchenDisplaySystem.tsx
+++ b/app/(waiter_order)/KitchenDisplaySystem.tsx
@@ -96,8 +96,8 @@ const KitchenDisplaySystem = () => {
   // Hooks & Context
   // --------------------------------------------------------------------------
   const { token } = useAuth();
-  const { orders, loading, error, fetchOrders } = useOrders(token, filter);
-  const { updateOrderStatus } = useOrderWebSocket(token, fetchOrders);
+  const { orders, loading, error, fetchOrders, updateOrderLocally } = useOrders(token, filter);
+  const { updateOrderStatus } = useOrderWebSocket(token);
   const { deductIngredientsForOrder } = useInventoryDeduction();
 
   // --------------------------------------------------------------------------
@@ -110,6 +110,7 @@ const KitchenDisplaySystem = () => {
   const tokenRef = useRef(token);
   const deductIngredientsRef = useRef(deductIngredientsForOrder);
   const updateOrderStatusRef = useRef(updateOrderStatus);
+  const updateOrderLocallyRef = useRef(updateOrderLocally);
 
   // Keep refs synchronised with the latest state / prop values
   useEffect(() => {
@@ -131,6 +132,10 @@ const KitchenDisplaySystem = () => {
   useEffect(() => {
     updateOrderStatusRef.current = updateOrderStatus;
   }, [updateOrderStatus]);
+
+  useEffect(() => {
+    updateOrderLocallyRef.current = updateOrderLocally;
+  }, [updateOrderLocally]);
 
   // --------------------------------------------------------------------------
   // Data Fetching
@@ -171,6 +176,7 @@ const KitchenDisplaySystem = () => {
     async (orderId: string, newStatus: string) => {
       const order = ordersRef.current.find((o) => o._id === orderId);
       if (!order) return;
+      const previousStatus = order.status;
 
       try {
         // ----- Inventory Deduction (only when moving to "preparing") -----
@@ -208,7 +214,6 @@ const KitchenDisplaySystem = () => {
               setShowDeductionWarning(true);
             }
 
-            // Record deduction result on the order (for audit/logging)
             await fetch(`${apiUrl}/api/orders/${orderId}/inventory`, {
               method: "POST",
               headers: {
@@ -216,9 +221,7 @@ const KitchenDisplaySystem = () => {
                 Authorization: `Bearer ${authToken}`,
               },
               body: JSON.stringify({
-                deductionStatus: deductionResult.success
-                  ? "completed"
-                  : "failed",
+                deductionStatus: deductionResult.success ? "completed" : "failed",
                 deductionData: deductionResult.data,
                 warning: deductionResult.warning,
                 timestamp: new Date().toISOString(),
@@ -227,14 +230,18 @@ const KitchenDisplaySystem = () => {
           }
         }
 
-        // ----- Update Order Status via WebSocket -----
-        updateOrderStatusRef.current(orderId, newStatus);
+        // ----- Optimistic update: change this card immediately -----
+        updateOrderLocallyRef.current(orderId, newStatus);
+
+        // ----- Persist to server (rollback on failure) -----
+        await updateOrderStatusRef.current(orderId, newStatus);
       } catch (error) {
         console.error("Error handling status update:", error);
+        updateOrderLocallyRef.current(orderId, previousStatus);
         alert("Failed to update order status");
       }
     },
-    [], // Intentionally empty – all dependencies are accessed via refs
+    [],
   );
 
   /** Opens the quick statistics panel. */

--- a/app/hooks/useOrderWebSocket.ts
+++ b/app/hooks/useOrderWebSocket.ts
@@ -1,97 +1,33 @@
-// ============================================================================
-// External Imports
-// ============================================================================
 import { useCallback } from "react";
 import Cookies from "js-cookie";
 
-// ============================================================================
-// Constants
-// ============================================================================
-
-/** Base API URL from environment variables. */
 const API_URL = process.env.NEXT_PUBLIC_API_URL;
 
-// ============================================================================
-// Custom Hook: useOrderWebSocket
-// ============================================================================
-
-/**
- * useOrderWebSocket Hook
- *
- * Provides a function to update an order's status via a REST API call.
- * This hook is typically used in WebSocket event handlers to reflect
- * real‑time status changes (e.g., waiter marks order as ready).
- *
- * @param token        - JWT authentication token (from `useAuth`). If null,
- *                       falls back to reading the token from cookies.
- * @param fetchOrders  - Callback to refresh the order list after a successful update.
- * @returns An object containing the `updateOrderStatus` function.
- */
-export const useOrderWebSocket = (
-  token: string | null,
-  fetchOrders: () => void,
-) => {
-  // --------------------------------------------------------------------------
-  // Public API
-  // --------------------------------------------------------------------------
-
-  /**
-   * Updates the status of a specific order by sending a PATCH request
-   * to the backend API.
-   *
-   * @param orderId     - Unique identifier of the order to update.
-   * @param newStatus   - The new status value (e.g., "confirmed", "preparing", "ready").
-   * @throws {Error}    If authentication fails or the API request is unsuccessful.
-   * @returns {Promise<void>}
-   */
+export const useOrderWebSocket = (token: string | null) => {
   const updateOrderStatus = useCallback(
     async (orderId: string, newStatus: string): Promise<void> => {
-      try {
-        // --------------------------------------------------------------------
-        // 1. Obtain a valid authentication token.
-        // --------------------------------------------------------------------
-        const authToken = token || Cookies.get("token");
-        if (!authToken) {
-          throw new Error(
-            "No authentication token found. Please log in again.",
-          );
+      const authToken = token || Cookies.get("token");
+      if (!authToken) {
+        throw new Error("No authentication token found. Please log in again.");
+      }
+
+      const response = await fetch(`${API_URL}/api/orders/${orderId}/status`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${authToken}`,
+        },
+        body: JSON.stringify({ status: newStatus }),
+      });
+
+      if (!response.ok) {
+        if (response.status === 401) {
+          throw new Error("Your session has expired. Please log in again.");
         }
-
-        // --------------------------------------------------------------------
-        // 2. Execute the PATCH request to update the order status.
-        // --------------------------------------------------------------------
-        const response = await fetch(
-          `${API_URL}/api/orders/${orderId}/status`,
-          {
-            method: "PATCH",
-            headers: {
-              "Content-Type": "application/json",
-              Authorization: `Bearer ${authToken}`,
-            },
-            body: JSON.stringify({ status: newStatus }),
-          },
-        );
-
-        // --------------------------------------------------------------------
-        // 3. Handle HTTP error responses.
-        // --------------------------------------------------------------------
-        if (!response.ok) {
-          if (response.status === 401) {
-            throw new Error("Your session has expired. Please log in again.");
-          }
-          throw new Error(`Failed to update order status: ${response.status}`);
-        }
-
-        // --------------------------------------------------------------------
-        // 4. Refresh the order list to reflect the change.
-        // --------------------------------------------------------------------
-        fetchOrders();
-      } catch (err) {
-        console.error("Error updating order status:", err);
-        throw err; // Re‑throw so the caller can handle it.
+        throw new Error(`Failed to update order status: ${response.status}`);
       }
     },
-    [token, fetchOrders], // Re‑create callback if token or fetchOrders changes.
+    [token],
   );
 
   return { updateOrderStatus };

--- a/app/hooks/useOrders.ts
+++ b/app/hooks/useOrders.ts
@@ -207,7 +207,24 @@ export const useOrders = (token: string | null, filter: string) => {
   }, [socket]);
 
   // --------------------------------------------------------------------------
+  // Optimistic Local Update
+  // --------------------------------------------------------------------------
+
+  const updateOrderLocally = useCallback(
+    (orderId: string, newStatus: string) => {
+      if (!isValidOrderStatus(newStatus)) return;
+      setOrders((prev) => {
+        const mapped = prev.map((o) =>
+          o._id === orderId ? { ...o, status: newStatus as Order["status"] } : o,
+        );
+        return filter !== "all" ? mapped.filter((o) => o.status === filter) : mapped;
+      });
+    },
+    [filter],
+  );
+
+  // --------------------------------------------------------------------------
   // Return Value
   // --------------------------------------------------------------------------
-  return { orders, loading, error, fetchOrders };
+  return { orders, loading, error, fetchOrders, updateOrderLocally };
 };


### PR DESCRIPTION
… local updates

Previously, clicking any status button triggered fetchOrders() which set loading:true, replaced the entire orders array with new object references, and caused every OrderCardWrapper memo to fail its items reference check — re-rendering all cards even though only one changed.

Fix:
- useOrders: add updateOrderLocally() that patches one order in-place, preserving all other orders object references so memo comparisons hold. Filters out the updated order if it no longer matches the active filter.
- useOrderWebSocket: remove fetchOrders param, hook now only fires the PATCH and throws on failure; caller owns all state transitions.
- KitchenDisplaySystem: optimistic update fires before the API call so the card changes instantly; rolls back to previousStatus on failure. Only the affected card ever re-renders.