### PR TITLE
Staging

### DIFF
--- a/app/(waiter_order)/WaiterOrderInterface.tsx
+++ b/app/(waiter_order)/WaiterOrderInterface.tsx
@@ -21,7 +21,7 @@ import { useLocalStorage } from "../hooks/useLocalStorage";
 import { useOrderManager } from "../hooks/useOrderManager";
 import { useInventoryDeduction } from "../hooks/useInventoryDeduction";
 
-import MenuItemCardForWaiter from "../presentation/components/MenuItemCard/MenuItemCardForWaiter";
+import MenuGrid from "../presentation/components/MenuItemCard/MenuGrid";
 import MenuItemRowWaiter from "../presentation/components/MenuItemCard/MenuItemRowWaiter";
 import OrderForm from "../presentation/components/OrderForm/OrderForm";
 import OrderSummary from "../presentation/components/OrderSummary/OrderSummary";
@@ -56,7 +56,7 @@ const WaiterOrderInterface = () => {
   const [searchTerm, setSearchTerm] = useState("");
   const [activeCategory, setActiveCategory] = useState("all");
   const [activeQuickFilter, setActiveQuickFilter] = useState<QuickFilter>("all");
-  const [viewMode, setViewMode] = useState<"list" | "card">("list");
+  const [viewMode, setViewMode] = useState<"list" | "card">("card");
 
   const [isCartOpen, setIsCartOpen] = useState(false);
   const [showStockWarning, setShowStockWarning] = useState(false);
@@ -115,6 +115,24 @@ const WaiterOrderInterface = () => {
     // Available items first, then unavailable
     return result.sort((a, b) => Number(b.availability) - Number(a.availability));
   }, [menuItems, searchTerm, activeCategory, activeQuickFilter]);
+
+  const cartQuantities = useMemo(() => {
+    const map: Record<string, number> = {};
+    for (const entry of orderManager.currentOrder) {
+      map[entry.menuItem._id] = entry.quantity;
+    }
+    return map;
+  }, [orderManager.currentOrder]);
+
+  const removeOneFromOrder = useCallback(
+    (item: MenuItem) => {
+      const current = orderManager.currentOrder.find(
+        (entry) => entry.menuItem._id === item._id,
+      );
+      if (current) orderManager.updateQuantity(item._id, current.quantity - 1);
+    },
+    [orderManager],
+  );
 
   // ---------------------------------------------------------------------------
   // Fetch
@@ -428,16 +446,13 @@ const WaiterOrderInterface = () => {
                 ))}
               </div>
             ) : (
-              <div className="p-4 grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-3">
-                {filteredItems.map((item, idx) => (
-                  <MenuItemCardForWaiter
-                    key={item._id}
-                    item={item}
-                    onAddToCart={orderManager.addToOrder}
-                    animationDelay={idx * 0.03}
-                  />
-                ))}
-              </div>
+              <MenuGrid
+                items={filteredItems}
+                cartQuantities={cartQuantities}
+                onAdd={orderManager.addToOrder}
+                onRemoveOne={removeOneFromOrder}
+                emptyHint={searchTerm ? "Try a different search" : "Change your filters"}
+              />
             )}
           </div>
         </div>

--- a/app/presentation/components/MenuItemCard/MenuCard.tsx
+++ b/app/presentation/components/MenuItemCard/MenuCard.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { ChefHat, Leaf, Minus } from "lucide-react";
+import { MenuItem } from "@/app/hooks/useMenuData";
+import { getCategorySwatch } from "./categoryColor";
+
+interface MenuCardProps {
+  item: MenuItem;
+  quantityInCart: number;
+  onAdd: (item: MenuItem) => void;
+  onRemoveOne?: (item: MenuItem) => void;
+}
+
+const MenuCard = ({ item, quantityInCart, onAdd, onRemoveOne }: MenuCardProps) => {
+  const swatch = getCategorySwatch(item.category);
+  const isVeg =
+    item.dietaryTags?.includes("vegetarian") || item.dietaryTags?.includes("vegan");
+  const inCart = quantityInCart > 0;
+  const disabled = !item.availability;
+
+  return (
+    <button
+      type="button"
+      onClick={() => !disabled && onAdd(item)}
+      disabled={disabled}
+      aria-label={`Add ${item.name} to order${inCart ? `, ${quantityInCart} in cart` : ""}`}
+      style={{ borderColor: inCart ? swatch.accent : undefined }}
+      className={`group relative flex h-full min-h-24 flex-col gap-2 rounded-xl border-2 p-3 text-left transition-all
+        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-900 focus-visible:ring-offset-1
+        ${
+          disabled
+            ? "cursor-not-allowed border-gray-100 bg-gray-50 opacity-60"
+            : `bg-white hover:-translate-y-0.5 hover:shadow-md active:scale-[0.97] active:shadow-sm ${
+                inCart ? "shadow-sm" : "border-gray-200"
+              }`
+        }`}
+    >
+      {/* Active cart indicator */}
+      {inCart && (
+        <span
+          style={{ backgroundColor: swatch.accent }}
+          className="absolute -right-2 -top-2 z-10 flex h-6 min-w-6 items-center justify-center rounded-full px-1.5 text-xs font-bold leading-none text-white shadow-md tabular-nums"
+        >
+          {quantityInCart}
+        </span>
+      )}
+
+      {/* Category tag + diet/chef markers */}
+      <div className="flex items-center justify-between gap-1.5">
+        <span
+          style={{ color: swatch.accent, backgroundColor: swatch.tint }}
+          className="max-w-[70%] truncate rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide"
+        >
+          {swatch.name || "Other"}
+        </span>
+        <span className="flex items-center gap-1 shrink-0">
+          {item.chefSpecial && <ChefHat className="h-3.5 w-3.5 text-amber-500" />}
+          {isVeg && <Leaf className="h-3.5 w-3.5 text-green-600" />}
+        </span>
+      </div>
+
+      {/* Name */}
+      <span className="line-clamp-2 flex-1 text-sm font-semibold leading-snug text-gray-900">
+        {item.name}
+      </span>
+
+      {/* Price + decrement */}
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-bold tabular-nums text-gray-900">
+          ${item.price.toFixed(2)}
+        </span>
+        {inCart && onRemoveOne && (
+          <span
+            role="button"
+            tabIndex={0}
+            aria-label={`Remove one ${item.name}`}
+            onClick={(e) => {
+              e.stopPropagation();
+              onRemoveOne(item);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                e.stopPropagation();
+                onRemoveOne(item);
+              }
+            }}
+            className="flex h-7 w-7 items-center justify-center rounded-md border border-gray-200 text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-900"
+          >
+            <Minus className="h-3.5 w-3.5" />
+          </span>
+        )}
+      </div>
+
+      {disabled && (
+        <span className="absolute inset-x-0 bottom-0 rounded-b-xl bg-gray-200/80 py-0.5 text-center text-[10px] font-semibold text-gray-500">
+          Unavailable
+        </span>
+      )}
+    </button>
+  );
+};
+
+export default MenuCard;

--- a/app/presentation/components/MenuItemCard/MenuGrid.tsx
+++ b/app/presentation/components/MenuItemCard/MenuGrid.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { Search } from "lucide-react";
+import { MenuItem } from "@/app/hooks/useMenuData";
+import MenuCard from "./MenuCard";
+
+interface MenuGridProps {
+  items: MenuItem[];
+  cartQuantities: Record<string, number>;
+  onAdd: (item: MenuItem) => void;
+  onRemoveOne?: (item: MenuItem) => void;
+  emptyHint?: string;
+}
+
+const MenuGrid = ({
+  items,
+  cartQuantities,
+  onAdd,
+  onRemoveOne,
+  emptyHint = "Change your filters",
+}: MenuGridProps) => {
+  if (items.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 text-gray-400">
+        <Search className="mb-3 h-8 w-8" />
+        <p className="text-sm font-medium">No items found</p>
+        <p className="mt-1 text-xs">{emptyHint}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-2 gap-2.5 p-3 sm:grid-cols-3 sm:gap-3 sm:p-4 xl:grid-cols-4">
+      {items.map((item) => (
+        <MenuCard
+          key={item._id}
+          item={item}
+          quantityInCart={cartQuantities[item._id] ?? 0}
+          onAdd={onAdd}
+          onRemoveOne={onRemoveOne}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default MenuGrid;

--- a/app/presentation/components/MenuItemCard/categoryColor.ts
+++ b/app/presentation/components/MenuItemCard/categoryColor.ts
@@ -1,0 +1,37 @@
+import { MenuItem } from "@/app/hooks/useMenuData";
+
+const PALETTE = [
+  "#ef4444",
+  "#f97316",
+  "#f59e0b",
+  "#84cc16",
+  "#22c55e",
+  "#14b8a6",
+  "#06b6d4",
+  "#3b82f6",
+  "#6366f1",
+  "#8b5cf6",
+  "#ec4899",
+  "#0ea5e9",
+] as const;
+
+export const getCategoryName = (category: MenuItem["category"]): string =>
+  typeof category === "string" ? category : category?.name || "";
+
+const hash = (value: string): number => {
+  let sum = 0;
+  for (let i = 0; i < value.length; i += 1) sum = (sum + value.charCodeAt(i)) % 9973;
+  return sum;
+};
+
+export interface CategorySwatch {
+  name: string;
+  accent: string;
+  tint: string;
+}
+
+export const getCategorySwatch = (category: MenuItem["category"]): CategorySwatch => {
+  const name = getCategoryName(category);
+  const accent = PALETTE[hash(name.toLowerCase()) % PALETTE.length];
+  return { name, accent, tint: `${accent}1A` };
+};


### PR DESCRIPTION
## Summary
Adds a fast, high-density **Grid View** to the Waiter Order System, optimized for taking orders quickly on a tablet, and makes it the default view.

- **`MenuCard`** — compact card-button; tap anywhere increments the cart quantity (via the existing `addToOrder` merge use case). Shows name, price, a per-category color tag, chef/veg markers, a **live quantity badge + accent border** as the active indicator, and a small decrement affordance.
- **`MenuGrid`** — responsive 2/3/4-column wrapper (phone → tablet → wide) with a self-contained empty state.
- **`categoryColor`** — deterministic category → hex color helper (inline styles, Tailwind-v4 purge-safe).
- **`WaiterOrderInterface`** — feeds cards a memoized `cartQuantities` map, wires a decrement handler, and defaults the order view to grid.

## Notes
- Filtering/state logic was already correct (combined category + tag), so it's unchanged.
- The old `MenuItemCardForWaiter` wrapper is now unused but left in place.
- Verified: `npx tsc --noEmit` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## Security checklist

- [ ] No secrets or `.env*` files committed
- [ ] No secrets placed in `NEXT_PUBLIC_*` env vars
- [ ] Route/UI access gated via `ProtectedRoute` / RBAC where applicable
- [ ] RBAC mirror (`app/config/rbac.ts`) kept in sync with the backend

## Verification

- [ ] `npx tsc --noEmit` passes
- [ ] `npm run test` passes
- [ ] Manual check of the affected screen(s)
