### PR TITLE
Dev

### DIFF
--- a/app/(admin)/analytics/loading.tsx
+++ b/app/(admin)/analytics/loading.tsx
@@ -1,0 +1,5 @@
+import DashboardSkeleton from "../../presentation/components/DashboardSkeleton";
+
+export default function Loading() {
+  return <DashboardSkeleton title="Kitchen Analytics Dashboard" />;
+}

--- a/app/(admin)/analytics/page.tsx
+++ b/app/(admin)/analytics/page.tsx
@@ -15,8 +15,9 @@
 // -----------------------------------------------------------------------------
 // IMPORTS
 // -----------------------------------------------------------------------------
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { useAuth } from "../../contexts/AuthContext";
+import { useStats } from "../../hooks/useStats";
 import KitchenStatsPanel from "../../presentation/components/KitchenStatsPanel/KitchenStatsPanel";
 import LoadingState from "../../(waiter_order)/common/LoadingState";
 import ErrorState from "../../(waiter_order)/common/ErrorState";
@@ -44,6 +45,12 @@ const AnalyticsPage = () => {
   // AUTHENTICATION
   // ===========================================================================
   const { token } = useAuth();
+
+  // Unified data source: the summary cards below read from the SAME
+  // `/api/orders/stats` endpoint that powers the embedded KitchenStatsPanel,
+  // so the two never diverge (previously the cards were hard-coded demo values
+  // while the panel showed live data).
+  const { stats, fetchStats } = useStats();
 
   // ===========================================================================
   // STATE DECLARATIONS
@@ -77,6 +84,39 @@ const AnalyticsPage = () => {
 
     return () => clearTimeout(timer);
   }, []);
+
+  /**
+   * Fetch the real aggregated stats once a token is available so the summary
+   * cards reflect live data. Kept separate from the skeleton timer above.
+   */
+  useEffect(() => {
+    if (token) {
+      fetchStats(token);
+    }
+  }, [token, fetchStats]);
+
+  // Derived, presentation-ready figures from the unified stats payload.
+  const summary = useMemo(() => {
+    const byStatus = stats?.ordersByStatus ?? {};
+    // "Completed" mirrors the panel's definition (ready + served).
+    const completed = (byStatus.ready ?? 0) + (byStatus.served ?? 0);
+    const totalFromStatus = Object.values(byStatus).reduce(
+      (sum, count) => sum + count,
+      0,
+    );
+    const totalOrders = stats?.todayOrderCount ?? totalFromStatus;
+    const inProgress = Math.max(totalOrders - completed, 0);
+    const topDish = stats?.bestSellingDishes?.[0];
+
+    return {
+      dailyRevenue: stats?.dailyEarnings ?? 0,
+      totalOrders,
+      completed,
+      inProgress,
+      avgOrderValue: stats?.avgOrderValue ?? 0,
+      topDish,
+    };
+  }, [stats]);
 
   // ===========================================================================
   // EVENT HANDLERS (memoized with useCallback)
@@ -261,10 +301,12 @@ const AnalyticsPage = () => {
                   Today&apos;s Revenue
                 </div>
               </div>
-              <div className="text-2xl font-bold text-gray-900">$1,856.50</div>
+              <div className="text-2xl font-bold text-gray-900">
+                ${summary.dailyRevenue.toFixed(2)}
+              </div>
               <div className="flex items-center text-xs text-green-600 mt-1">
                 <TrendingUp className="w-3 h-3 mr-1" />
-                +12.5% from yesterday
+                Today&apos;s total
               </div>
             </div>
 
@@ -278,9 +320,11 @@ const AnalyticsPage = () => {
                   Total Orders
                 </div>
               </div>
-              <div className="text-2xl font-bold text-gray-900">68</div>
+              <div className="text-2xl font-bold text-gray-900">
+                {summary.totalOrders}
+              </div>
               <div className="text-xs text-gray-500 mt-1">
-                42 completed • 26 in progress
+                {summary.completed} completed • {summary.inProgress} in progress
               </div>
             </div>
 
@@ -291,13 +335,15 @@ const AnalyticsPage = () => {
                   <Clock className="w-5 h-5 text-purple-600" />
                 </div>
                 <div className="text-sm text-gray-500 font-medium">
-                  Avg Prep Time
+                  Avg Order Value
                 </div>
               </div>
-              <div className="text-2xl font-bold text-gray-900">14m 23s</div>
-              <div className="flex items-center text-xs text-green-600 mt-1">
+              <div className="text-2xl font-bold text-gray-900">
+                ${summary.avgOrderValue.toFixed(2)}
+              </div>
+              <div className="flex items-center text-xs text-gray-500 mt-1">
                 <TrendingUp className="w-3 h-3 mr-1" />
-                -2m faster than avg
+                Per order today
               </div>
             </div>
 
@@ -312,10 +358,12 @@ const AnalyticsPage = () => {
                 </div>
               </div>
               <div className="text-xl font-bold text-gray-900">
-                Classic Burger
+                {summary.topDish?.name ?? "—"}
               </div>
               <div className="text-xs text-gray-500 mt-1">
-                28 sold • $425 revenue
+                {summary.topDish
+                  ? `${summary.topDish.quantity} sold • $${summary.topDish.revenue.toFixed(2)} revenue`
+                  : "No sales yet"}
               </div>
             </div>
           </div>

--- a/app/(admin)/dashboard/loading.tsx
+++ b/app/(admin)/dashboard/loading.tsx
@@ -1,0 +1,5 @@
+import DashboardSkeleton from "../../presentation/components/DashboardSkeleton";
+
+export default function Loading() {
+  return <DashboardSkeleton />;
+}

--- a/app/(admin)/inventory/loading.tsx
+++ b/app/(admin)/inventory/loading.tsx
@@ -1,0 +1,5 @@
+import DashboardSkeleton from "../../presentation/components/DashboardSkeleton";
+
+export default function Loading() {
+  return <DashboardSkeleton title="Inventory" />;
+}

--- a/app/(waiter_order)/waiter_order/loading.tsx
+++ b/app/(waiter_order)/waiter_order/loading.tsx
@@ -1,0 +1,5 @@
+import DashboardSkeleton from "../../presentation/components/DashboardSkeleton";
+
+export default function Loading() {
+  return <DashboardSkeleton title="Waiter Order System" />;
+}

--- a/app/(waiter_order)/waiter_order/page.tsx
+++ b/app/(waiter_order)/waiter_order/page.tsx
@@ -5,8 +5,6 @@ import { useAuth } from "../../contexts/AuthContext";
 import { ProtectedRoute } from "../../presentation/components/ProtectedRoute/ProtectedRoute";
 import WaiterOrderInterface from "../WaiterOrderInterface";
 import KitchenDisplaySystem from "../KitchenDisplaySystem";
-import { SocketProvider } from "@/app/contexts/SocketContext";
-import { WebSocketProvider } from "@/app/contexts/WebSocketContext";
 
 const WaiterOrderPage = () => {
   const { user } = useAuth();
@@ -58,13 +56,11 @@ const WaiterOrderPage = () => {
           </div>
         </div>
 
-        {/* Full-height content */}
+        {/* Full-height content — realtime providers come from the root layout,
+            so this view shares the single persistent socket instead of opening
+            a second, page-scoped connection that churned on every navigation. */}
         <div className="flex-1 overflow-hidden">
-          <SocketProvider>
-            <WebSocketProvider>
-              {activeTab === "order" ? <WaiterOrderInterface /> : <KitchenDisplaySystem />}
-            </WebSocketProvider>
-          </SocketProvider>
+          {activeTab === "order" ? <WaiterOrderInterface /> : <KitchenDisplaySystem />}
         </div>
       </div>
     </ProtectedRoute>

--- a/app/billing/loading.tsx
+++ b/app/billing/loading.tsx
@@ -1,0 +1,5 @@
+import DashboardSkeleton from "../presentation/components/DashboardSkeleton";
+
+export default function Loading() {
+  return <DashboardSkeleton title="Billing & Payments" />;
+}

--- a/app/contexts/SocketContext.tsx
+++ b/app/contexts/SocketContext.tsx
@@ -78,19 +78,31 @@ export const SocketProvider: React.FC<{ children: React.ReactNode }> = ({
   // --------------------------------------------------------------------------
   const [socket, setSocket] = useState<Socket | null>(null);
   const [isConnected, setIsConnected] = useState(false);
-  const { token, user } = useAuth();
+  const { token, user, isLoading } = useAuth();
+
+  // Depend on stable primitives, not the `user` object reference. Optimistic
+  // profile edits (`updateUser`) produce a new `user` object with the same
+  // identity fields; keying the effect on the object would tear down and
+  // re-establish the socket on every such change (connection churn).
+  const userId = user?._id;
+  const userRole = user?.role;
+  const userName = user?.name;
 
   // --------------------------------------------------------------------------
   // Side Effects
   // --------------------------------------------------------------------------
 
   /**
-   * Effect: Establish Socket.IO connection when authentication becomes available.
-   * Runs whenever the token or user object changes.
+   * Effect: Establish Socket.IO connection once authentication is fully resolved.
+   * Gated on `!isLoading` so we never open a socket mid-verification (before the
+   * token/role are known), and re-runs only when the identity primitives change.
    */
   useEffect(() => {
-    // Guard: require both token and user role to connect
-    if (!token || !user?.role) {
+    // Guard: wait until the initial session verification has settled.
+    if (isLoading) return;
+
+    // Guard: require both token and user role to connect.
+    if (!token || !userRole) {
       console.log("Socket: Missing token or role, skipping connection");
       return;
     }
@@ -104,8 +116,8 @@ export const SocketProvider: React.FC<{ children: React.ReactNode }> = ({
       },
       query: {
         token: token,
-        role: user.role,
-        userId: user._id, // Include user ID for server-side room management
+        role: userRole,
+        userId: userId, // Include user ID for server-side room management
       },
       transports: ["websocket", "polling"],
       timeout: 10000,
@@ -121,11 +133,11 @@ export const SocketProvider: React.FC<{ children: React.ReactNode }> = ({
       setIsConnected(true);
 
       // Notify server about the user's role and identity
-      newSocket.emit("set_role", user.role);
+      newSocket.emit("set_role", userRole);
       newSocket.emit("user_connected", {
-        userId: user._id,
-        role: user.role,
-        name: user.name,
+        userId: userId,
+        role: userRole,
+        name: userName,
       });
     });
 
@@ -145,8 +157,8 @@ export const SocketProvider: React.FC<{ children: React.ReactNode }> = ({
     newSocket.on("reconnect", (attemptNumber) => {
       console.log("Socket: Reconnected after", attemptNumber, "attempts");
       setIsConnected(true);
-      if (user) {
-        newSocket.emit("user_reconnected", user._id);
+      if (userId) {
+        newSocket.emit("user_reconnected", userId);
       }
     });
 
@@ -165,14 +177,19 @@ export const SocketProvider: React.FC<{ children: React.ReactNode }> = ({
     // ------------------------------------------------------------------------
     return () => {
       console.log("Socket: Cleaning up connection");
-      if (user) {
-        newSocket.emit("user_disconnected", user._id);
+      if (userId) {
+        newSocket.emit("user_disconnected", userId);
       }
+      // Remove listeners before disconnecting so a lingering handler can't fire
+      // against a torn-down instance, then close the underlying connection to
+      // eliminate the leak on unmount / re-run.
+      newSocket.removeAllListeners();
       newSocket.disconnect();
       setSocket(null);
       setIsConnected(false);
     };
-  }, [token, user]); // Dependencies: re‑establish when token or user changes
+    // Re-establish only when the token or identity primitives actually change.
+  }, [token, isLoading, userId, userRole, userName]);
 
   // --------------------------------------------------------------------------
   // Render

--- a/app/lib/sidebar/sidebarConfig.tsx
+++ b/app/lib/sidebar/sidebarConfig.tsx
@@ -67,6 +67,12 @@ export interface SidebarItem {
   roles?: string[];
   /** If true, shows a "New" indicator. */
   isNew?: boolean;
+  /**
+   * Controls Next.js `<Link>` prefetching. Leave undefined (default prefetch)
+   * for hot paths; set `false` on heavy or low-priority routes so they don't
+   * fire `?_rsc=` prefetch requests for every visible link on each render.
+   */
+  prefetch?: boolean;
 }
 
 /**
@@ -227,6 +233,7 @@ export class SidebarConfig {
           text: "Analytics",
           icon: <BarChart className={this.ICON_SIZE} />,
           link: "/analytics",
+          prefetch: false,
           roles: ["admin", "manager"],
         },
       ],
@@ -262,6 +269,7 @@ export class SidebarConfig {
           text: "Inventory Dashboard",
           icon: <Package className={this.ICON_SIZE} />,
           link: "/inventory/IngredientStockDashboard",
+          prefetch: false,
           roles: ["admin", "manager"],
         },
         {
@@ -269,6 +277,7 @@ export class SidebarConfig {
           text: "Stock Take",
           icon: <ClipboardCheck className={this.ICON_SIZE} />,
           link: "/inventory/audit",
+          prefetch: false,
           roles: ["admin", "manager"],
         },
         {
@@ -276,6 +285,7 @@ export class SidebarConfig {
           text: "Billing & Payments",
           icon: <CreditCard className={this.ICON_SIZE} />,
           link: "/billing",
+          prefetch: false,
           roles: ["admin", "manager", "cashier", "waiter"],
         },
       ],
@@ -304,6 +314,7 @@ export class SidebarConfig {
           text: "Promotions",
           icon: <Zap className={this.ICON_SIZE} />,
           link: "/promotions",
+          prefetch: false,
           roles: ["admin"],
         },
         {
@@ -325,6 +336,7 @@ export class SidebarConfig {
           text: "Shift Schedule",
           icon: <Calendar className={this.ICON_SIZE} />,
           link: "/schedule",
+          prefetch: false,
           roles: ["admin", "manager"],
         },
       ],
@@ -380,6 +392,7 @@ export class SidebarConfig {
           text: "Settings",
           icon: <Settings className={this.ICON_SIZE} />,
           link: "/settings",
+          prefetch: false,
           roles: ["admin", "manager"],
         },
         {
@@ -387,6 +400,7 @@ export class SidebarConfig {
           text: "Notifications",
           icon: <Bell className={this.ICON_SIZE} />,
           link: "/notifications",
+          prefetch: false,
           roles: ["admin", "manager", "waiter", "chef"],
         },
         {
@@ -394,6 +408,7 @@ export class SidebarConfig {
           text: "Help & Support",
           icon: <HelpCircle className={this.ICON_SIZE} />,
           link: "/help",
+          prefetch: false,
           roles: ["admin", "manager", "waiter", "chef"],
         },
       ],

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { Home, ArrowLeft } from "lucide-react";
+
+/**
+ * Global 404 boundary.
+ *
+ * Rendered as a fixed, full-viewport overlay (`z-[100]`, above the sidebar at
+ * `z-60`) so a dead route reads as a standalone page rather than content nested
+ * inside the authenticated dashboard shell. The real-time socket never opens
+ * here for unauthenticated visitors — it is gated on a resolved token/role in
+ * `SocketContext` — so a mistyped URL from a logged-out client spins up no
+ * websocket connection.
+ */
+export default function NotFound() {
+  const router = useRouter();
+
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-white dark:bg-neutral-950 px-6">
+      <div className="w-full max-w-md text-center">
+        <p className="text-7xl font-bold tracking-tight text-indigo-500">404</p>
+        <h1 className="mt-4 text-2xl font-semibold text-gray-900 dark:text-white">
+          Page not found
+        </h1>
+        <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
+          The page you&apos;re looking for doesn&apos;t exist or has been moved.
+        </p>
+
+        <div className="mt-8 flex items-center justify-center gap-3">
+          <button
+            onClick={() => router.back()}
+            className="inline-flex items-center gap-2 rounded-lg border border-gray-200 dark:border-white/15 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-white/5 transition-colors"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            Go back
+          </button>
+          <Link
+            href="/dashboard"
+            className="inline-flex items-center gap-2 rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 transition-colors"
+          >
+            <Home className="w-4 h-4" />
+            Go to dashboard
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/presentation/components/DashboardSkeleton.tsx
+++ b/app/presentation/components/DashboardSkeleton.tsx
@@ -1,0 +1,47 @@
+/**
+ * DashboardSkeleton – server-rendered placeholder streamed by route-level
+ * `loading.tsx` Suspense boundaries.
+ *
+ * Because it carries no `"use client"` directive and no data dependencies, it is
+ * emitted with the initial server response: the persistent shell (root layout +
+ * sidebar) stays on screen and this skeleton streams in immediately while the
+ * client page component hydrates and fetches, instead of showing a blank frame.
+ */
+const DashboardSkeleton = ({ title }: { title?: string }) => {
+  return (
+    <div className="min-h-screen p-4 md:p-6">
+      <div className="max-w-7xl mx-auto">
+        <div className="mb-8">
+          {title ? (
+            <h1 className="text-2xl md:text-3xl font-bold text-gray-300">
+              {title}
+            </h1>
+          ) : (
+            <div className="h-8 w-64 bg-gray-200 rounded mb-4 animate-pulse" />
+          )}
+          <div className="h-4 w-96 max-w-full bg-gray-200 rounded animate-pulse mt-3" />
+        </div>
+
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div
+              key={i}
+              className="bg-white p-6 rounded-xl border border-gray-200 animate-pulse"
+            >
+              <div className="h-4 w-24 bg-gray-200 rounded mb-3" />
+              <div className="h-8 w-32 bg-gray-200 rounded mb-2" />
+              <div className="h-3 w-20 bg-gray-200 rounded" />
+            </div>
+          ))}
+        </div>
+
+        <div className="bg-white rounded-xl border border-gray-200 p-6 animate-pulse">
+          <div className="h-6 w-48 bg-gray-200 rounded mb-6" />
+          <div className="h-64 bg-gray-100 rounded" />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DashboardSkeleton;

--- a/app/presentation/components/layout/Sidebar/CollapsibleSidebar.tsx
+++ b/app/presentation/components/layout/Sidebar/CollapsibleSidebar.tsx
@@ -275,6 +275,7 @@ const CollapsibleSidebar = ({ user, onLogout }: CollapsibleSidebarProps) => {
                           // Regular link item (no children)
                           <Link
                             href={item.link || "#"}
+                            prefetch={item.prefetch}
                             onClick={() => setIsOpen(false)}
                             className={`w-full group/item flex items-center px-3 py-3 rounded-lg transition-all duration-200 relative ${
                               isActive
@@ -325,6 +326,7 @@ const CollapsibleSidebar = ({ user, onLogout }: CollapsibleSidebarProps) => {
                               <Link
                                 key={child.id}
                                 href={child.link || "#"}
+                                prefetch={child.prefetch}
                                 onClick={() => setIsOpen(false)}
                                 className={`block px-3 py-2 rounded-lg text-sm transition-all duration-200 ${
                                   child.link === pathname


### PR DESCRIPTION
## Summary
Fixes 5 App Router / routing / Socket.io issues from the architectural audit. Each item was verified with `tsc --noEmit` and a full `next build` (both green).

## Changes

### 1. Socket.io lifecycle & hydration race
- Gate connection on **resolved** auth (`!isLoading && token && role`) so it never opens mid-verification.
- Key the effect on **stable identity primitives** (`userId`/`userRole`/`userName`) instead of the `user` object — optimistic profile edits no longer tear down/recreate the socket (connection churn).
- `removeAllListeners()` before `disconnect()` on cleanup.
- **Removed the duplicate `SocketProvider`/`WebSocketProvider` nested inside the `waiter_order` page** — the app now shares the single persistent root socket instead of opening a second connection that churned on navigation. This was the source of the "Connected… twice" leak.

### 2. Streaming shell (scoped)
- Added route-level `loading.tsx` Suspense boundaries backed by a server-rendered `DashboardSkeleton` for `analytics`, `dashboard`, `inventory`, `billing`, and `waiter_order`, so the persistent shell paints immediately and each route streams its skeleton.
- _Note:_ full RSC/SSR conversion is constrained by the client-cookie auth model — see follow-up below.

### 3. RSC prefetch storm
- Added an opt-out `prefetch` flag to the sidebar config; set `prefetch={false}` on heavy/low-priority routes (analytics, inventory dashboard, stock take, billing, promotions, schedule, settings, notifications, help).

### 4. `/analytics` data discrepancy (real bug)
- The summary cards were **hard-coded demo values** (`$1,856.50`, `68`) while the panel below read live `/api/orders/stats`. Wired the cards to the **same `useStats` endpoint**; derive completed/in-progress the same way the panel does, and replaced the unbacked "Avg Prep Time" card with real "Avg Order Value" + top-dish from `bestSellingDishes`.

### 5. 404 / error boundary isolation
- Added a self-contained full-viewport `not-found.tsx`. Combined with the socket auth-gate, dead routes open **no** websocket for unauthenticated visitors.

## Verification
- `npx tsc --noEmit` → exit 0
- `npm run build` → exit 0, all routes compile (`/_not-found` emitted)

## Follow-up (not in this PR)
Relocating the authenticated shell into a `(dashboard)` route-group layout would enable full RSC/SSR streaming and keep the socket providers entirely out of the 404 boundary for logged-in users too. That's a larger refactor (rewrites relative imports across many files) — proposed as its own branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Security checklist

- [ ] No secrets or `.env*` files committed
- [ ] No secrets placed in `NEXT_PUBLIC_*` env vars
- [ ] Route/UI access gated via `ProtectedRoute` / RBAC where applicable
- [ ] RBAC mirror (`app/config/rbac.ts`) kept in sync with the backend

## Verification

- [ ] `npx tsc --noEmit` passes
- [ ] `npm run test` passes
- [ ] Manual check of the affected screen(s)
